### PR TITLE
Enable specifying a query limit to work around the default limit of 1000 when querying collectors.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,10 @@ default['sumologic']['log_sources']['default_category'] = 'log'
 default['sumologic']['api_timeout'] = 60
 default['sumologic']['custom_install'] = false
 
-#databag location for credentials
+# databag location for credentials
 default['sumologic']['credentials']['bag_name'] = 'sumo-creds'
 default['sumologic']['credentials']['item_name'] = 'api-creds'
 
+# Limit the number of collectors queried, default is 1000.
+# We are at 1121 Collectors.
+default['sumologic']['collector_query_limit'] = '1000'

--- a/libraries/sumo_source_provider.rb
+++ b/libraries/sumo_source_provider.rb
@@ -21,13 +21,30 @@ class Chef
           name: node.name,
           api_username: databag_creds['userID'] || node['sumologic']['userID'],
           api_password: databag_creds['password'] || node['sumologic']['password'],
-          api_timeout: node['sumologic']['api_timeout']
+          api_timeout: node['sumologic']['api_timeout'],
+          query_limit: node['sumologic']['collector_query_limit']
         )
 
         # Does out collector exist?
         if not @@collector.exist?
           # No, bug out.
-          raise Chef::Exceptions::ValidationFailed,"A SumoLogic Collector named: `#{node.name}` does not exist.\n\nTo resolve this isssue:\n\n\t1. Stop the SumoCollector process:\n\t\t`sudo /opt/SumoCollector/collector stop`\n\n\t2. Remove the SumoCollector directory.\n\t\t`sudo rm -r /opt/SumoCollector`\n\n\t3. Rerun chef-client.\n\t\t`sudo chef-client`"
+          raise Chef::Exceptions::ValidationFailed,
+            "SumoLogic Collector missing from: `https://api.sumologic.com/api/v1/collectors/`"\
+            "\nEither a SumoLogic Collector named: `#{node.name}` does not exist, or was not returned in collector list\n"\
+            "within the limit of `#{node['sumologic']['collector_query_limit']}` collectors.\n"\
+            "\nLog into the SumoLogic WebUI and verify the collector exists.\n"\
+            "\nIf the collector does exist:"\
+            "\n\n\tPlease increase the value of:"\
+            "\n\n\t\t`default['sumologic']['collector_query_limit']`"\
+            "\n\t\t\tOR"\
+            "\n\t\t`node['sumologic']['collector_query_limit']`"\
+            "\n\nIf the collector does not exist:"\
+            "\n\n\t1. Stop the SumoCollector process:"\
+            "\n\t\t`sudo /opt/SumoCollector/collector stop`"\
+            "\n\n\t2. Remove the SumoCollector directory."\
+            "\n\t\t`sudo rm -r /opt/SumoCollector`"\
+            "\n\n\t3. Rerun chef-client."\
+            "\n\t\t`sudo chef-client`\n\n"
         end
 
         # Is our collector in Json/Local Config mode?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ranjib@pagerduty.com'
 license          'Apache 2.0'
 description      "Installs/configures Sumo Logic's sumocollector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.3'
+version          '1.3.4'
 
 depends 'sumologic-collector'
 


### PR DESCRIPTION
Amend error message.